### PR TITLE
added package.json due to plugin installation failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cordova-device-accounts",
+  "version": "1.0.0",
+  "description": "Cordova plugin to get the device accounts on Android",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/loicknuchel/cordova-device-accounts.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/loicknuchel/cordova-device-accounts/issues"
+  },
+  "homepage": "https://github.com/loicknuchel/cordova-device-accounts#readme"
+}


### PR DESCRIPTION
I was not able to install the plugin using cordova 7.0.1.

It failed due to missing package.json file with following error:

Error: Failed to fetch plugin https://github.com/loicknuchel/cordova-device-accounts.git via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Error: cmd: Command failed with exit code 4294963228 Error output:
npm ERR! addLocal Could not install C:\Users\xxx\AppData\Local\Temp\npm-1748-af17a967\git-cache-d05fa533b970afaca1a2ec1083558934\34e6bfe08663d4b82865662d7ef032a64254c80d
npm ERR! Windows_NT 10.0.15063
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install" "https://github.com/loicknuchel/cordova-device-accounts.git" "--save"
npm ERR! node v5.5.0
npm ERR! npm  v3.3.12
npm ERR! code EISDIR
npm ERR! errno -4068
npm ERR! syscall read

npm ERR! eisdir EISDIR: illegal operation on a directory, read
npm ERR! eisdir This is most likely not a problem with npm itself
npm ERR! eisdir and is related to npm not being able to find a package.json in
npm ERR! eisdir a package you are trying to install.

npm ERR! Please include the following file with any support request:
npm ERR!     D:\Development\build\mx-cordova\node_modules\npm-debug.log
